### PR TITLE
Update grafana version to 6.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM grafana/grafana:5.3.2
+FROM grafana/grafana:6.7.2
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/Dockerfile.kubernetes
+++ b/Dockerfile.kubernetes
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM grafana/grafana:5.3.2
+FROM grafana/grafana:6.7.2
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

- Update grafana version to 6.7.2


Because the low grafana version doesn't support Loki datasource