### PR TITLE
fix field error for connector io dashboard

### DIFF
--- a/dashboards.kubernetes/connector_sink.json
+++ b/dashboards.kubernetes/connector_sink.json
@@ -331,9 +331,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_sink_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_sink_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],
@@ -419,9 +419,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_sink_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_sink_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],
@@ -507,9 +507,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_sink_sink_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_sink_sink_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],
@@ -595,9 +595,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_sink_system_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_sink_system_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],

--- a/dashboards.kubernetes/connector_source.json
+++ b/dashboards.kubernetes/connector_source.json
@@ -331,9 +331,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_source_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_source_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],
@@ -419,9 +419,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_source_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_source_received_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],
@@ -507,9 +507,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_source_source_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_source_source_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],
@@ -595,9 +595,9 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(pulsar_source_system_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[1m]) )by (cluster, exported_namespace, connector)",
+            "expr": "sum(rate(pulsar_source_system_exceptions_total{cluster=~\"$cluster\",exported_namespace=~\"$namespace\", exported_name=~\"$connector\" }[5m]) )by (cluster, fqfn)",
             "interval": "",
-            "legendFormat": "{{exported_namespace}}/{{connector}}",
+            "legendFormat": "{{cluster}}-{{fqfn}}",
             "refId": "A"
           }
         ],


### PR DESCRIPTION
I make some tests with the latest pulsar io image and find some errors in prom expr.
I also increase the range in expr from `1m` to `5m` as the dashboard show no data when scraping interval is greater than 1m. 
After change, the dashboards for source and sink should be like the following images.
![image](https://user-images.githubusercontent.com/1431033/123019124-71d8f880-d402-11eb-8e1f-f85986282a47.png)

![image](https://user-images.githubusercontent.com/1431033/123019017-3f2f0000-d402-11eb-979e-5c38eabccfdc.png)
