### PR TITLE
Upgrade grafana version to 8.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM grafana/grafana:7.4.3-ubuntu
+FROM grafana/grafana:8.2.0-ubuntu
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/Dockerfile.kubernetes
+++ b/Dockerfile.kubernetes
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM grafana/grafana:7.4.3-ubuntu
+FROM grafana/grafana:8.2.0-ubuntu
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
The new version of grafana adds many interesting features, so in order to use them, consider upgrading grafana
* Upgrade grafana version to 8.2.0

This is a big version of the change and I think I need to spend some time testing it first:
