### PR TITLE
1. add `job` variable

### DIFF
--- a/dashboards.template/messaging.json.j2
+++ b/dashboards.template/messaging.json.j2
@@ -1,2136 +1,2310 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_TEST-CLUSTER",
-      "label": "{{ PULSAR_CLUSTER }}",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.3.2"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": "5.0.0"
-    }
-  ],
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": "-- Grafana --",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
-  },
-  "description": "Messaging Related Metrics Per Namespace",
-  "editable": true,
-  "gnetId": null,
-  "graphTooltip": 0,
-  "id": null,
-  "iteration": 1543830651050,
-  "links": [],
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 24,
-      "panels": [],
-      "title": "Overview",
-      "type": "row"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "{{ PULSAR_CLUSTER }}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 0,
-        "y": 1
-      },
-      "id": 26,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
+    "__inputs": [
         {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
+            "name": "DS_TEST-CLUSTER",
+            "label": "{{ PULSAR_CLUSTER }}",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
         }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pulsar_topics_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Topics",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "{{ PULSAR_CLUSTER }}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 4,
-        "y": 1
-      },
-      "id": 27,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pulsar_producers_count{cluster=~\"$cluster\", job=~\".*broker\",  namespace=~\"$namespace\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Producers",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "{{ PULSAR_CLUSTER }}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 8,
-        "y": 1
-      },
-      "id": 29,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pulsar_subscriptions_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Subscriptions",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "{{ PULSAR_CLUSTER }}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 12,
-        "y": 1
-      },
-      "id": 28,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pulsar_consumers_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Consumers",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "{{ PULSAR_CLUSTER }}",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 16,
-        "y": 1
-      },
-      "id": 31,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pulsar_msg_backlog{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Msg Backlog",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "{{ PULSAR_CLUSTER }}",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 20,
-        "y": 1
-      },
-      "id": 30,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "sum(pulsar_storage_size{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Storage Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 6
-      },
-      "id": 18,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 7
-          },
-          "id": 16,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_rate_in{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) by (cluster, namespace)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
-              "metric": "pulsar_rate_in",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Local publish rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "msg/s",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 7
-          },
-          "id": 2,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_rate_out{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) by (cluster, namespace)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
-              "metric": "pulsar_rate_out",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Local delivery rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "msg / s",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 14
-          },
-          "id": 5,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_throughput_in{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) by (cluster, namespace)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
-              "metric": "pulsar_throughput_in",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Local publish throughput (bytes/s)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "Bps",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "description": "",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 14
-          },
-          "id": 8,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_throughput_out{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) by (cluster, namespace)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
-              "metric": "pulsar_throughput_out",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Local delivery throughput (bytes/s)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "Bps",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "decimals": 0,
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 21
-          },
-          "id": 7,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_topics_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "topics",
-              "metric": "pulsar_topics_count",
-              "refId": "D",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_producers_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "producers",
-              "metric": "pulsar_producers_count",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_subscriptions_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "subscriptions",
-              "metric": "pulsar_subscriptions_count",
-              "refId": "B",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_consumers_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "consumers",
-              "metric": "pulsar_consumers_count",
-              "refId": "C",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Topics - Producers - Subscriptions - Consumers",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [
-              "current"
-            ]
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "short",
-              "label": "count",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 21
-          },
-          "id": 4,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_msg_backlog{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) by (cluster, namespace)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
-              "metric": "pulsar_msg_backlog",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Local backlog",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "Messages",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "Namespaces",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 7
-      },
-      "id": 20,
-      "panels": [
-        {
-          "aliasColors": {
-            "0 - 0.5 ms": "#2F575E",
-            "0.5 - 1 ms": "#3F6833",
-            "1 - 5 ms": "#629E51",
-            "10 - 20 ms": "#E5A8E2",
-            "100 - 200 ms": "#EF843C",
-            "20 - 50 ms": "#65C5DB",
-            "200 ms - 1 s": "#EA6460",
-            "5 - 10 ms": "#1F78C1",
-            "50 - 100 ms": "#E5AC0E",
-            "< +Inf ms": "#BF1B00",
-            "< 0.5 ms": "#508642",
-            "> 1 s": "#BF1B00"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 5,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 8
-          },
-          "id": 3,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 0,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "< 100 ms",
-              "yaxis": 1
-            }
-          ],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_0_5{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "0 - 0.5 ms",
-              "metric": "pulsar_add_entry_latency_le_0_5",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_1{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "0.5 - 1 ms",
-              "metric": "pulsar_add_entry_latency_le_1",
-              "refId": "B",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_5{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "1 - 5 ms",
-              "metric": "pulsar_add_entry_latency_le_5",
-              "refId": "C",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_10{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "5 - 10 ms",
-              "metric": "pulsar_add_entry_latency_le_10",
-              "refId": "D",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_20{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "10 - 20 ms",
-              "metric": "pulsar_add_entry_latency_le_20",
-              "refId": "E",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_50{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "20 - 50 ms",
-              "metric": "pulsar_add_entry_latency_le_50",
-              "refId": "F",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_100{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "50 - 100 ms",
-              "metric": "pulsar_add_entry_latency_le_100",
-              "refId": "G",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_200{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "100 - 200 ms",
-              "metric": "pulsar_add_entry_latency_le_200",
-              "refId": "H",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_le_1000{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "200 ms - 1 s",
-              "metric": "pulsar_add_entry_latency_le_1000",
-              "refId": "I",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_storage_write_latency_overflow{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "> 1 s",
-              "metric": "pulsar_add_entry_latency_overflow",
-              "refId": "J",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Storage Write Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "msg / s",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 8
-          },
-          "id": 9,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_storage_size{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "$namespace",
-              "metric": "pulsar_storage_size",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Storage Size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "decbytes",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "description": "Rate of writes into storage (can be lower than publish rate, when batching is enabled)",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 15
-          },
-          "id": 13,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_storage_write_latency_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "$namespace",
-              "metric": "pulsar_storage_write_rate",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Storage Write Rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "entry / s",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "description": "Reads from bookies",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 15
-          },
-          "id": 14,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_storage_read_latency_count{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "read rate",
-              "metric": "pulsar_storage_read_rate",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Storage read entry rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "entries / s",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 6,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 22
-          },
-          "id": 12,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 0,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "< 2 KB",
-              "yaxis": 1
-            }
-          ],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_entry_size_le_128{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 128 bytes",
-              "metric": "pulsar_entry_size_le_128",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_le_512{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 512 bytes",
-              "metric": "pulsar_entry_size_le_512",
-              "refId": "B",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_le_1_kb{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 1 KB",
-              "metric": "pulsar_entry_size_le_1_kb",
-              "refId": "C",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_le_2_kb{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 2 KB",
-              "metric": "pulsar_entry_size_le_2_kb",
-              "refId": "D",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_le_4_kb{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 4 KB",
-              "metric": "pulsar_entry_size_le_4_kb",
-              "refId": "E",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_le_16_kb{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 16 KB",
-              "metric": "pulsar_entry_size_le_16_kb",
-              "refId": "F",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_le_100_kb{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 100 KB",
-              "metric": "pulsar_entry_size_le_100_kb",
-              "refId": "G",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_le_1_mb{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "< 1 MB",
-              "metric": "pulsar_entry_size_le_1_mb",
-              "refId": "H",
-              "step": 10
-            },
-            {
-              "expr": "sum(pulsar_entry_size_overflow{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) / 60.0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "> 1 MB",
-              "metric": "pulsar_entry_size_le_overflow",
-              "refId": "I",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Storage entry size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "msg / s",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "Storage",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "id": 22,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 9
-          },
-          "id": 10,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_replication_rate_in{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\", remote_cluster!=\"local\"}) by (cluster, remote_cluster)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{remote_cluster}} → {{cluster}}' }}",
-              "metric": "pulsar_rate_in",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Incoming replication rate | any → $cluster",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "msg / s",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 9
-          },
-          "id": 11,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_replication_rate_out{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"})",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{cluster}} → {{remote_cluster}}' }}",
-              "metric": "pulsar_rate",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Outgoing replication rate | $cluster → any",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "msg / s",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "{{ PULSAR_CLUSTER }}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 16
-          },
-          "id": 15,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(pulsar_replication_backlog{cluster=~\"$cluster\", job=~\".*broker\", namespace=~\"$namespace\"}) by (cluster, remote_cluster)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ '{{cluster}} → {{remote_cluster}}' }}",
-              "metric": "pulsar_replication_backlog",
-              "refId": "A",
-              "step": 10
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Replication backlog | $cluster → any",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "messages",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "Geo Replication",
-      "type": "row"
-    }
-  ],
-  "refresh": "1m",
-  "schemaVersion": 16,
-  "style": "dark",
-  "tags": [
-    "messaging",
-    "namespaces"
-  ],
-  "templating": {
-    "list": [
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "{{ PULSAR_CLUSTER }}",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "pulsar_rate_in{cluster=~\".+\"}",
-        "refresh": 2,
-        "regex": "/.*[^_]cluster=\\\"([^\\\"]+)\\\".*/",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "{{ PULSAR_CLUSTER }}",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Namespace",
-        "multi": false,
-        "name": "namespace",
-        "options": [],
-        "query": "pulsar_rate_in{namespace=~\".+\", cluster=~\"$cluster\"}",
-        "refresh": 2,
-        "regex": "/.*namespace=\\\"([^\\\"]+)\\\".*/",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      }
-    ]
-  },
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
     ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
-  "timezone": "browser",
-  "title": "Messaging Metrics",
-  "uid": "sWPi0L-mk",
-  "version": 4
+    "__requires": [
+        {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "5.3.2"
+        },
+        {
+            "type": "panel",
+            "id": "graph",
+            "name": "Graph",
+            "version": "5.0.0"
+        },
+        {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "5.0.0"
+        },
+        {
+            "type": "panel",
+            "id": "singlestat",
+            "name": "Singlestat",
+            "version": "5.0.0"
+        }
+    ],
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
+            }
+        ]
+    },
+    "description": "Messaging Related Metrics Per Namespace",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 25,
+    "iteration": 1644393252856,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 24,
+            "panels": [],
+            "title": "Overview",
+            "type": "row"
+        },
+        {
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 0,
+                "y": 1
+            },
+            "id": 26,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.3.3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_topics_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Topics",
+            "type": "stat"
+        },
+        {
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 4,
+                "y": 1
+            },
+            "id": 27,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.3.3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_producers_count{cluster=~\"$cluster\", job=~\"$job\",  namespace=~\"$namespace\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Producers",
+            "type": "stat"
+        },
+        {
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 8,
+                "y": 1
+            },
+            "id": 29,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.3.3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_subscriptions_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Subscriptions",
+            "type": "stat"
+        },
+        {
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 12,
+                "y": 1
+            },
+            "id": 28,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.3.3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_consumers_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Consumers",
+            "type": "stat"
+        },
+        {
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 16,
+                "y": 1
+            },
+            "id": 31,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.3.3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_msg_backlog{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Msg Backlog",
+            "type": "stat"
+        },
+        {
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 20,
+                "y": 1
+            },
+            "id": 30,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.3.3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_storage_size{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Storage Size",
+            "type": "stat"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 18,
+            "panels": [
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 0,
+                        "y": 7
+                    },
+                    "hiddenSeries": false,
+                    "id": 16,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "hideEmpty": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_rate_in{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) by (cluster, namespace)",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
+                            "metric": "pulsar_rate_in",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Local publish rate",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:71",
+                            "format": "short",
+                            "label": "msg/s",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:72",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 12,
+                        "y": 7
+                    },
+                    "hiddenSeries": false,
+                    "id": 2,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_rate_out{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) by (cluster, namespace)",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
+                            "metric": "pulsar_rate_out",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Local delivery rate",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:126",
+                            "format": "short",
+                            "label": "msg / s",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:127",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 0,
+                        "y": 14
+                    },
+                    "hiddenSeries": false,
+                    "id": 5,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_throughput_in{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) by (cluster, namespace)",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
+                            "metric": "pulsar_throughput_in",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Local publish throughput (bytes/s)",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:181",
+                            "format": "Bps",
+                            "label": "",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:182",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "description": "",
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 12,
+                        "y": 14
+                    },
+                    "hiddenSeries": false,
+                    "id": 8,
+                    "legend": {
+                        "alignAsTable": false,
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_throughput_out{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) by (cluster, namespace)",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
+                            "metric": "pulsar_throughput_out",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Local delivery throughput (bytes/s)",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:232",
+                            "format": "Bps",
+                            "label": "",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:233",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "decimals": 0,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 0,
+                        "y": 21
+                    },
+                    "hiddenSeries": false,
+                    "id": 7,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_topics_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "topics",
+                            "metric": "pulsar_topics_count",
+                            "refId": "D",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_producers_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "producers",
+                            "metric": "pulsar_producers_count",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_subscriptions_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "subscriptions",
+                            "metric": "pulsar_subscriptions_count",
+                            "refId": "B",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_consumers_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "consumers",
+                            "metric": "pulsar_consumers_count",
+                            "refId": "C",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Topics - Producers - Subscriptions - Consumers",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": [
+                            "current"
+                        ]
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:283",
+                            "format": "short",
+                            "label": "count",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:284",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 12,
+                        "y": 21
+                    },
+                    "hiddenSeries": false,
+                    "id": 4,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_msg_backlog{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) by (cluster, namespace)",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
+                            "metric": "pulsar_msg_backlog",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Local backlog",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:334",
+                            "format": "short",
+                            "label": "Messages",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:335",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                }
+            ],
+            "title": "Namespaces",
+            "type": "row"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 7
+            },
+            "id": 20,
+            "panels": [
+                {
+                    "aliasColors": {
+                        "0 - 0.5 ms": "#2F575E",
+                        "0.5 - 1 ms": "#3F6833",
+                        "1 - 5 ms": "#629E51",
+                        "10 - 20 ms": "#E5A8E2",
+                        "100 - 200 ms": "#EF843C",
+                        "20 - 50 ms": "#65C5DB",
+                        "200 ms - 1 s": "#EA6460",
+                        "5 - 10 ms": "#1F78C1",
+                        "50 - 100 ms": "#E5AC0E",
+                        "< +Inf ms": "#BF1B00",
+                        "< 0.5 ms": "#508642",
+                        "> 1 s": "#BF1B00"
+                    },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 5,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 0,
+                        "y": 8
+                    },
+                    "hiddenSeries": false,
+                    "id": 3,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 0,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:405",
+                            "alias": "< 100 ms",
+                            "yaxis": 1
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_0_5{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "0 - 0.5 ms",
+                            "metric": "pulsar_add_entry_latency_le_0_5",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_1{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "0.5 - 1 ms",
+                            "metric": "pulsar_add_entry_latency_le_1",
+                            "refId": "B",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_5{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "1 - 5 ms",
+                            "metric": "pulsar_add_entry_latency_le_5",
+                            "refId": "C",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_10{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "5 - 10 ms",
+                            "metric": "pulsar_add_entry_latency_le_10",
+                            "refId": "D",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_20{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "10 - 20 ms",
+                            "metric": "pulsar_add_entry_latency_le_20",
+                            "refId": "E",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_50{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "20 - 50 ms",
+                            "metric": "pulsar_add_entry_latency_le_50",
+                            "refId": "F",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_100{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "hide": false,
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "50 - 100 ms",
+                            "metric": "pulsar_add_entry_latency_le_100",
+                            "refId": "G",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_200{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "100 - 200 ms",
+                            "metric": "pulsar_add_entry_latency_le_200",
+                            "refId": "H",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_le_1000{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "200 ms - 1 s",
+                            "metric": "pulsar_add_entry_latency_le_1000",
+                            "refId": "I",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_overflow{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "> 1 s",
+                            "metric": "pulsar_add_entry_latency_overflow",
+                            "refId": "J",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Storage Write Latency",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:412",
+                            "format": "short",
+                            "label": "msg / s",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:413",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 12,
+                        "y": 8
+                    },
+                    "hiddenSeries": false,
+                    "id": 9,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_size{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "$namespace",
+                            "metric": "pulsar_storage_size",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Storage Size",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:463",
+                            "format": "decbytes",
+                            "label": "",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:464",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "description": "Rate of writes into storage (can be lower than publish rate, when batching is enabled)",
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 0,
+                        "y": 15
+                    },
+                    "hiddenSeries": false,
+                    "id": 13,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_write_latency_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "$namespace",
+                            "metric": "pulsar_storage_write_rate",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Storage Write Rate",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:518",
+                            "format": "short",
+                            "label": "entry / s",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:519",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "description": "Reads from bookies",
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 12,
+                        "y": 15
+                    },
+                    "hiddenSeries": false,
+                    "id": 14,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": false,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_storage_read_latency_count{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "read rate",
+                            "metric": "pulsar_storage_read_rate",
+                            "refId": "A",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Storage read entry rate",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:569",
+                            "format": "short",
+                            "label": "entries / s",
+                            "logBase": 1,
+                            "min": "0",
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:570",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 6,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 6,
+                        "w": 24,
+                        "x": 0,
+                        "y": 22
+                    },
+                    "hiddenSeries": false,
+                    "id": 12,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 0,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "alertThreshold": true
+                    },
+                    "percentage": false,
+                    "pluginVersion": "8.3.3",
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [
+                        {
+                            "$$hashKey": "object:620",
+                            "alias": "< 2 KB",
+                            "yaxis": 1
+                        }
+                    ],
+                    "spaceLength": 10,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_128{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 128 bytes",
+                            "metric": "pulsar_entry_size_le_128",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_512{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 512 bytes",
+                            "metric": "pulsar_entry_size_le_512",
+                            "refId": "B",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_1_kb{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 1 KB",
+                            "metric": "pulsar_entry_size_le_1_kb",
+                            "refId": "C",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_2_kb{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 2 KB",
+                            "metric": "pulsar_entry_size_le_2_kb",
+                            "refId": "D",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_4_kb{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 4 KB",
+                            "metric": "pulsar_entry_size_le_4_kb",
+                            "refId": "E",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_16_kb{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 16 KB",
+                            "metric": "pulsar_entry_size_le_16_kb",
+                            "refId": "F",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_100_kb{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 100 KB",
+                            "metric": "pulsar_entry_size_le_100_kb",
+                            "refId": "G",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_le_1_mb{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "< 1 MB",
+                            "metric": "pulsar_entry_size_le_1_mb",
+                            "refId": "H",
+                            "step": 10
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "UOPngcJnk"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(pulsar_entry_size_overflow{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) / 60.0",
+                            "format": "time_series",
+                            "interval": "",
+                            "intervalFactor": 2,
+                            "legendFormat": "> 1 MB",
+                            "metric": "pulsar_entry_size_le_overflow",
+                            "refId": "I",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Storage entry size",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "$$hashKey": "object:627",
+                            "format": "short",
+                            "label": "msg / s",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "$$hashKey": "object:628",
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                }
+            ],
+            "title": "Storage",
+            "type": "row"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 8
+            },
+            "id": 22,
+            "panels": [],
+            "title": "Geo Replication",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "8.3.3",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_replication_rate_in{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\", remote_cluster!=\"local\"}) by (cluster, remote_cluster)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ '{{cluster}} → {{remote_cluster}}' }}",
+                    "metric": "pulsar_rate_in",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Incoming replication rate | any → $cluster",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:739",
+                    "format": "short",
+                    "label": "msg / s",
+                    "logBase": 1,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:740",
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "8.3.3",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_replication_rate_out{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"})",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ '{{cluster}} → {{remote_cluster}}' }}",
+                    "metric": "pulsar_rate",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Outgoing replication rate | $cluster → any",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:790",
+                    "format": "short",
+                    "label": "msg / s",
+                    "logBase": 1,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:791",
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "8.3.3",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "UOPngcJnk"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(pulsar_replication_backlog{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}) by (cluster, remote_cluster)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{ '{{cluster}} → {{remote_cluster}}' }}",
+                    "metric": "pulsar_replication_backlog",
+                    "refId": "A",
+                    "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Replication backlog | $cluster → any",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:841",
+                    "format": "short",
+                    "label": "messages",
+                    "logBase": 1,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:842",
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        }
+    ],
+    "refresh": "",
+    "schemaVersion": 34,
+    "style": "dark",
+    "tags": [
+        "messaging",
+        "namespaces"
+    ],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "UOPngcJnk"
+                },
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": {
+                    "query": "pulsar_rate_in{cluster=~\".+\"}",
+                    "refId": "standalone-cluster-Variable-Query"
+                },
+                "refresh": 2,
+                "regex": "/.*[^_]cluster=\\\"([^\\\"]+)\\\".*/",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "UOPngcJnk"
+                },
+                "definition": "",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "query": "pulsar_rate_in{namespace=~\".+\", cluster=~\"$cluster\"}",
+                    "refId": "standalone-namespace-Variable-Query"
+                },
+                "refresh": 2,
+                "regex": "/.*namespace=\\\"([^\\\"]+)\\\".*/",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "definition": "pulsar_rate_in{cluster=~\"$cluster\",job=~\".+\"}",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Job",
+                "multi": false,
+                "name": "job",
+                "options": [],
+                "query": {
+                    "query": "pulsar_rate_in{cluster=~\"$cluster\",job=~\".+\"}",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "/.*[^_]job=\\\"([^\\\"]+)\\\".*/",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Messaging Metrics",
+    "uid": "sWPi0L-mk",
+    "version": 23,
+    "weekStart": ""
 }

--- a/dashboards.template/transaction.json.j2
+++ b/dashboards.template/transaction.json.j2
@@ -1,34 +1,34 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_TEST-CLUSTER",
-      "label": "{{ PULSAR_CLUSTER }}",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.1.0"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "5.0.0"
-    }
-  ],
+    "__inputs": [
+     {
+       "name": "DS_TEST-CLUSTER",
+       "label": "{{ PULSAR_CLUSTER }}",
+       "description": "",
+       "type": "datasource",
+       "pluginId": "prometheus",
+       "pluginName": "Prometheus"
+     }
+   ],
+   "__requires": [
+     {
+       "type": "grafana",
+       "id": "grafana",
+       "name": "Grafana",
+       "version": "5.1.0"
+     },
+     {
+       "type": "panel",
+       "id": "graph",
+       "name": "Graph",
+       "version": "5.0.0"
+     },
+     {
+       "type": "datasource",
+       "id": "prometheus",
+       "name": "Prometheus",
+       "version": "5.0.0"
+     }
+   ],
   "annotations": {
     "list": [
       {
@@ -49,14 +49,14 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
-  "iteration": 1629125684213,
+  "id": 31,
+  "iteration": 1644478958752,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -103,11 +103,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_created_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"})",
+          "expr": "sum(pulsar_txn_created_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"})",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
@@ -118,7 +122,6 @@
       "type": "stat"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -164,11 +167,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_active_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"})",
+          "expr": "sum(pulsar_txn_active_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"})",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
@@ -179,7 +186,6 @@
       "type": "stat"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -226,11 +232,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_committed_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"})",
+          "expr": "sum(pulsar_txn_committed_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"})",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
@@ -241,7 +251,6 @@
       "type": "stat"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -288,11 +297,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_timeout_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"})",
+          "expr": "sum(pulsar_txn_timeout_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"})",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
@@ -303,7 +316,6 @@
       "type": "stat"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -333,7 +345,6 @@
         "y": 0
       },
       "id": 18,
-      "interval": null,
       "maxDataPoints": 100,
       "options": {
         "colorMode": "value",
@@ -350,11 +361,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_aborted_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"})",
+          "expr": "sum(pulsar_txn_aborted_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"})",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
@@ -365,7 +380,6 @@
       "type": "stat"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -437,8 +451,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "irate(pulsar_txn_created_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}[1m])",
+          "expr": "irate(pulsar_txn_created_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}[1m])",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
@@ -450,7 +468,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -522,8 +539,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "irate(pulsar_txn_committed_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}[1m])",
+          "expr": "irate(pulsar_txn_committed_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}[1m])",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
@@ -535,7 +556,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -607,8 +627,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "irate(pulsar_txn_aborted_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}[1m])",
+          "expr": "irate(pulsar_txn_aborted_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}[1m])",
           "interval": "",
           "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
           "queryType": "randomWalk",
@@ -619,7 +643,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -691,8 +714,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "irate(pulsar_txn_timeout_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}[1m])",
+          "expr": "irate(pulsar_txn_timeout_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}[1m])",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
@@ -704,7 +731,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -776,8 +802,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "irate(pulsar_txn_append_log_count{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}[1m])",
+          "expr": "irate(pulsar_txn_append_log_count{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}[1m])",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ '{{cluster}} - {{namespace}}' }}",
@@ -789,7 +819,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": "{{ PULSAR_CLUSTER }}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -847,7 +876,6 @@
         "y": 21
       },
       "id": 12,
-      "maxDataPoints": null,
       "options": {
         "legend": {
           "calcs": [],
@@ -860,8 +888,12 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_10{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_10{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "0 - 10 ms",
@@ -869,8 +901,12 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_20{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_20{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -878,8 +914,12 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_50{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_50{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -887,8 +927,12 @@
           "refId": "C"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_100{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_100{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -896,8 +940,12 @@
           "refId": "D"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_500{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_500{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -905,8 +953,12 @@
           "refId": "E"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_1000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_1000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -914,8 +966,12 @@
           "refId": "F"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_5000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_5000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -923,8 +979,12 @@
           "refId": "G"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_15000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_15000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -932,8 +992,12 @@
           "refId": "H"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_30000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_30000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -941,8 +1005,12 @@
           "refId": "I"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_60000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_60000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -950,8 +1018,12 @@
           "refId": "J"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_300000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_300000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -959,8 +1031,12 @@
           "refId": "K"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_1500000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_1500000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -968,8 +1044,12 @@
           "refId": "L"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_1500000{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_1500000{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -977,8 +1057,12 @@
           "refId": "M"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "UOPngcJnk"
+          },
           "exemplar": true,
-          "expr": "sum(pulsar_txn_execution_latency_le_overflow{cluster=~\"$cluster\", job=~\".*broker\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
+          "expr": "sum(pulsar_txn_execution_latency_le_overflow{cluster=~\"$cluster\", job=~\"$job\", coordinator_id=~\"$coordinator_id\"}) / 60.0",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -991,22 +1075,22 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 30,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "{{ PULSAR_CLUSTER }}",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "UOPngcJnk"
+        },
         "definition": "pulsar_txn_active_count{cluster=~\".+\"}",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Cluster",
@@ -1024,16 +1108,16 @@
         "type": "query"
       },
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "{{ PULSAR_CLUSTER }}",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "UOPngcJnk"
+        },
         "definition": "pulsar_txn_committed_count{cluster=~\"$cluster\", coordinator_id=~\".+\", }",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "CoordinatorId",
@@ -1049,16 +1133,40 @@
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Pulsar",
+          "value": "Pulsar"
+        },
+        "definition": "pulsar_txn_active_count{cluster=~\"$cluster\",job=~\".+\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "pulsar_txn_active_count{cluster=~\"$cluster\",job=~\".+\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/.*[^_]job=\\\"([^\\\"]+)\\\".*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Pulsar - Transaction",
   "uid": "wUI6Ck7nz",
-  "version": 31
+  "version": 9,
+  "weekStart": ""
 }


### PR DESCRIPTION
Motivation

according to https://github.com/streamnative/community-faq/issues/48, I find that if I start a prometheus and grafana-dashboard locally, some dashboards such as `Transaction`、`Messaging`、`Proxy`、`Overview` will not display table value. It takes no matter with our own docker image.

Modification
1. Changed `Transaction Dashboard` and `Messaging Dashboard`
2. Add `Job` variable
3. Modify PromQL. (such as:  change from `sum(pulsar_topics_count{cluster=~"$cluster", job=~".*broker", namespace=~"$namespace"})` to `sum(pulsar_topics_count{cluster=~"$cluster", job=~"$job", namespace=~"$namespace"})`)