### PR TITLE
add env as data sources for j2 when render dashboards [Variables not be rendered in these generated dashboards]

### DIFF
--- a/scripts/generate_dashboards.sh
+++ b/scripts/generate_dashboards.sh
@@ -102,7 +102,7 @@ else
 
   # apply environment variables to pulsar datasource provisioning yaml file
   cp ${DASHBOARD_HOME}/conf/provisioning/datasources.yml ${DASHBOARD_HOME}/target/datasources.yml
-  j2 ${DASHBOARD_HOME}/target/datasources.yml > ${DATASOURCES_OUTPUT_DIR}/pulsar.yml
+  j2 --import-env= --undefined ${DASHBOARD_HOME}/target/datasources.yml > ${DATASOURCES_OUTPUT_DIR}/pulsar.yml
 
   echo "Your pulsar data source is generated as ${DATASOURCES_OUTPUT_DIR}/pulsar.yml"
 
@@ -113,7 +113,7 @@ else
 
     # Only attempt to render via jinja2 if the file is a jinja2 template
     if [[ "${item}" == *".j2" ]]; then
-      j2 ${DASHBOARD_HOME}/dashboards.template/${item} > ${DASHBOARDS_OUTPUT_DIR}/${OUTPUT_FILE}
+      j2 --import-env= --undefined ${DASHBOARD_HOME}/dashboards.template/${item} > ${DASHBOARDS_OUTPUT_DIR}/${OUTPUT_FILE}
     else
       sed "s/{{ PULSAR_CLUSTER }}/${PULSAR_CLUSTER}/" ${DASHBOARD_HOME}/dashboards.template/${item} > ${DASHBOARDS_OUTPUT_DIR}/${OUTPUT_FILE}
     fi


### PR DESCRIPTION
As the generate tool use environment variables for the following and just run generate_dashboards.sh:
        - PULSAR_PROMETHEUS_URL
        - PULSAR_CLUSTER
        - PULSAR_CUSTOM_PROMETHEUS
        - GF_LOKI_URL
        - GF_LOKI_DATASOURCE_NAME

It is necessary to specify env as data sources for j2 when render dashboards.