### PR TITLE
Remove redundant code (cluster2-pulsar menu entry)

### DIFF
--- a/dashboards.kubernetes/overview.json
+++ b/dashboards.kubernetes/overview.json
@@ -2985,12 +2985,6 @@
             "selected": false,
             "text": "{{ PULSAR_CLUSTER }}",
             "value": "{{ PULSAR_CLUSTER }}"
-          },
-          {
-            "$$hashKey": "object:361",
-            "selected": false,
-            "text": "cluster2-pulsar",
-            "value": "cluster2-pulsar"
           }
         ],
         "query": "bookkeeper_server_ADD_ENTRY{cluster=~\".+\"}",


### PR DESCRIPTION
The `pulsar-devenv` on the screenshot is my cluster.

The `cluster2-pulsar` isn't mine.

<img width="329" alt="Screenshot 2022-11-05 at 7 12 45 PM" src="https://user-images.githubusercontent.com/9302460/200134871-cd845f9c-d2b8-4d74-b62f-6c8216678fc1.png">

I didn't test the change but hopefully, it should work.
