### PR TITLE
doc: fix typos and markdown lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Apache Pulsar Grafana Dashboard
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fstreamnative%2Fapache-pulsar-grafana-dashboard.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fstreamnative%2Fapache-pulsar-grafana-dashboard?ref=badge_shield)
 
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fstreamnative%2Fapache-pulsar-grafana-dashboard.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fstreamnative%2Fapache-pulsar-grafana-dashboard?ref=badge_shield)
 
 The Grafana dashboard docker image is available at
 [Docker Hub](https://hub.docker.com/r/streamnative/apache-pulsar-grafana-dashboard).
 
-To use this dashboard image, provide the following environment variables: 
+To use this dashboard image, provide the following environment variables:
 
 - *PULSAR_PROMETHEUS_URL*: The HTTP URL that points to your prometheus service. For example, `http://<prometheus-host>:9090`.
 - *PULSAR_CLUSTER*: The pulsar cluster name. The cluster name is aligned with your prometheus configuration.
@@ -16,6 +16,7 @@ To use this dashboard image, provide the following environment variables:
 To display the metrics correctly with this dashboard, configure your Prometheus server to collect metrics from Pulsar correctly.
 
 1. Attach your prometheus service to an extra label - `cluster`. The cluster name is aligned with the `PULSAR_CLUSTER` name you have provided to the grafana dashboard.
+
    ```yaml
    global:
      ...
@@ -36,48 +37,48 @@ How to configure your prometheus server to collect the metrics of a Pulsar clust
 
 Use this Grafana Dashboard on a standalone cluster.
 
-#### Start Pulsar Standalone
+### Start Pulsar Standalone
 
 Download the pulsar binary and follow the instruction to
 [start a standalone cluster](http://pulsar.apache.org/docs/en/standalone/) on your computer.
 
-#### Start Prometheus
+### Start Prometheus
 
-1. Generate a Prometheus config file.
+#### 1. Generate a Prometheus config file
 
 Two options are available to generate a prometheus config file.
+
 - Copy the template file [prometheus/standalone.yml.template](prometheus/standalone.yml.template), and replace `{{ STANDALONE_HOST }}` with your IP address of the machine running pulsar standalone.
 - Install [j2cli](https://github.com/kolypto/j2cli). j2cli is a command-line tool for templating [Jinja2](http://jinja.pocoo.org/docs/)
 template files. You can use j2cli to generate a Prometheus config file from the standalone template.
 
 ```bash
 
-$ STANDALONE_HOST="$(ifconfig | grep "inet " | grep -v 127.0.0.1 | awk '{ print $2 }')" j2 prometheus/standalone.yml.template > /tmp/standalone.prometheus.yml
+STANDALONE_HOST="$(ifconfig | grep "inet " | grep -v 127.0.0.1 | awk '{ print $2 }')" j2 prometheus/standalone.yml.template > /tmp/standalone.prometheus.yml
 
 ```
 
 In Ubuntu, set `STANDALONE_HOST` as below.
+
 ```bash
 
-$ STANDALONE_HOST="$(ifconfig | grep "inet " | grep -v 127.0.0.1 | awk '{ print $2 }' | awk -F ':' '{ print $2 }' | awk 'NR==2')" j2 prometheus/standalone.yml.template > /tmp/standalone.prometheus.yml
+STANDALONE_HOST="$(ifconfig | grep "inet " | grep -v 127.0.0.1 | awk '{ print $2 }' | awk -F ':' '{ print $2 }' | awk 'NR==2')" j2 prometheus/standalone.yml.template > /tmp/standalone.prometheus.yml
 
 ```
 
 If it doesn't work properly, you can set the IP manually.
 
-
-2. Run Prometheus with the generated prometheus config file.
-
+#### 2. Run Prometheus with the generated prometheus config file
 
 ```bash
 docker run -p 9090:9090 -v /tmp/standalone.prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus
 ```
 
-After running the prometheus successfully, you have access to http://localhost:9090/targets, where you can see prometheus detecting all pulsar components, shown as follows.
+After running the prometheus successfully, you have access to <http://localhost:9090/targets>, where you can see prometheus detecting all pulsar components, shown as follows.
 
-![](images/prometheus-targets.png?raw=true)
+![screenshot: prometheus targets](images/prometheus-targets.png?raw=true)
 
-#### Start Grafana Dashbard
+### Start Grafana Dashboard
 
 When you have a Pulsar standalone and a Prometheus server connecting to the Pulsar standalone, you can start with the Grafana Dashboard.
 
@@ -95,7 +96,7 @@ export PULSAR_PROMETHEUS_URL=http://$(ifconfig | grep "inet " | grep -v 127.0.0.
 
 If it doesn't work properly, you can set the IP manually.  
 
-Access the Grafana Dashboard at http://localhost:3000.
+Access the Grafana Dashboard at <http://localhost:3000>.
 The default user name is `admin`, the default password is `happypulsaring`, and they are set in the [conf/grafana.ini](conf/grafana.ini) file.
 
 ## Import dashboard to your Grafana installation
@@ -112,7 +113,7 @@ the dashboard files that you can use to import to your installation.
 ./scripts/generate_dashboards.sh <prometheus-url> <clustername>
 ```
 
-- `<prometheus-url>`: The url points to your prometheus servcie. E.g. `http://localhost:9090`
+- `<prometheus-url>`: The url points to your prometheus service. E.g. `http://localhost:9090`
 - `<clustername>`: Your pulsar cluster name.
 
 The datasource yaml file and dashboard json files will be generated under `target/datasources` and `target/dashboards`.
@@ -125,8 +126,8 @@ These dashboards are:
 
 - *Overview*: This renders the overview health of a Pulsar cluster.
 - *Messaging Metrics*: This renders the metrics related to Pulsar messaging (e.g. producers, consumers, msg backlog and so on).
-- *Proxy Metrics*: This renders the metrics related to Pulsar proxies if you have run proxies in your Pulsar clusters. _This doesn't apply to a standalone cluster._
-- *Bookie Metrics*: This renders the metrics related to Bookies. _This doesn't apply to a Standalone cluster since a Pulsar standalone doesn't expose bookie metrics._
+- *Proxy Metrics*: This renders the metrics related to Pulsar proxies if you have run proxies in your Pulsar clusters. (This doesn't apply to a standalone cluster.)
+- *Bookie Metrics*: This renders the metrics related to Bookies. (This doesn't apply to a Standalone cluster since a Pulsar standalone doesn't expose bookie metrics.)
 - *ZooKeeper*: This renders the metrics related to ZooKeeper cluster.
 - *JVM Metrics*: This renders the jvm related metrics of all the components in a Pulsar cluster (For example, proxies, brokers, bookies, and so on).
 
@@ -144,6 +145,6 @@ make
 
 Checkout [Makefile](Makefile) for the details of the command used for building the docker image.
 
-
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fstreamnative%2Fapache-pulsar-grafana-dashboard.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fstreamnative%2Fapache-pulsar-grafana-dashboard?ref=badge_large)


### PR DESCRIPTION
Fixed typos and some markdown lint in `README.md`.